### PR TITLE
[TEC-4230] Return authorization value should not change on receive

### DIFF
--- a/app/models/spree/return_authorization_decorator.rb
+++ b/app/models/spree/return_authorization_decorator.rb
@@ -5,9 +5,6 @@ Spree::ReturnAuthorization.class_eval do
   RETURN_AUTHORIZATION_LOGGER.info('start ReturnAuthorization processing')
 
   has_one :avalara_transaction
-  self.state_machine.before_transition :to => :received,
-                                       :do => :avalara_capture_finalize,
-                                       :if => :avalara_eligible?
 
   def avalara_eligible?
     Spree::Config.avatax_iseligible && order_has_avalara_transaction?

--- a/spec/models/spree/return_authorization_decorator_spec.rb
+++ b/spec/models/spree/return_authorization_decorator_spec.rb
@@ -59,15 +59,5 @@ describe Spree::ReturnAuthorization, type: :model do
       return_authorization.receive!
       expect(return_authorization.state).to eq("received")
     end
-
-    it "should receive avalara_capture_finalize" do
-      expect(return_authorization).to receive(:avalara_capture_finalize)
-      return_authorization.receive!
-    end
-
-    it 'avalara_transaction should receive commit_avatax_final when return auth is received' do
-      expect(return_authorization.order.avalara_transaction).to receive(:commit_avatax_final)
-      return_authorization.receive!
-    end
   end
 end


### PR DESCRIPTION
### What problem is the code solving?
When a return authorization is calculated, it is generated with a value:
![image](https://user-images.githubusercontent.com/9217968/98149749-63a68e00-1eac-11eb-9bf2-cc4236b14785.png)

But after click on the `receive` button, the amount of the return authorization changes:
![image](https://user-images.githubusercontent.com/9217968/98149760-66a17e80-1eac-11eb-871f-6d0133b47605.png)

### How does this change address the problem?
Avatax gem triggered a method on the receive state change on the state machine, that modified the amount of the return authorization:
`self.amount = @rtn_tax['TotalAmount'].to_f.abs + @rtn_tax['TotalTax'].to_f.abs unless @rtn_tax[:TotalTax] == '0.00'`
`self.save`
By removing the call to the method, the return authorization amount will not change.

### Why is this the best solution?
The amount should never change after the return authorization is generated. The amount already takes into consideration taxes in the moment it is created, so once it is validated it shouldn't change automatically.

### Share the knowledge
This override on Return Authorization model is part of Spree 2.3. Master branch of the spree_avatax_official does not override Return Authorization.