### PR TITLE
[DL-537] Configuring callback to notify avalara when RMA is marked as received

### DIFF
--- a/spec/models/spree/return_authorization_decorator_spec.rb
+++ b/spec/models/spree/return_authorization_decorator_spec.rb
@@ -59,5 +59,15 @@ describe Spree::ReturnAuthorization, type: :model do
       return_authorization.receive!
       expect(return_authorization.state).to eq("received")
     end
+
+    it 'should receive avalara_capture_finalize' do
+      expect(return_authorization).to receive(:avalara_capture_finalize)
+      return_authorization.receive!
+    end
+
+    it 'avalara_transaction should receive commit_avatax_final when return auth is received' do
+      expect(return_authorization.order.avalara_transaction).to receive(:commit_avatax_final)
+      return_authorization.receive!
+    end
   end
 end


### PR DESCRIPTION
### What problem is the code solving?
Avalara is not tracking returns done in Spree.

### How does this change address the problem?
- adding the `before_transition` to call `avalara_capture_finalize` method when the RMA is marked as **received**. This is to match the same logic as written by boomerdigital here: https://github.com/boomerdigital/spree_avatax_certified/blob/2-3-stable/app/models/spree/return_authorization_decorator.rb#L8
- avoiding updating the return_authorziation's amount within the `avalara_capture_finalize` method. This is to avoid an old bug reported some time ago here: https://mejuritech.atlassian.net/browse/TEC-4230. 

### Why is this the best solution?
These changes would be the minimal ones to make sure to start tracking returns in avalara.

### Share the knowledge
Even though returns are tracked in avalara. The amounts are still slightly off. This is because in Spree we are returning the tax amount as well, but when exporting the return transaction into avalara at some point it is recalculating the tax over the final amount. Regardless, of that this is a step forward to having this working properly again. 
