### PR TITLE
[DL-559] return transactions amount fix

### DIFF
--- a/app/models/spree_avatax_certified/line.rb
+++ b/app/models/spree_avatax_certified/line.rb
@@ -117,7 +117,7 @@ module SpreeAvataxCertified
         :TaxCode => line_item.tax_category.try(:description) || 'P0000000',
         :ItemCode => line_item.variant.sku,
         :Qty => quantity,
-        :Amount => -amount.to_f,
+        :Amount => -amount + return_line_item_taxes(line_item, quantity),
         :OriginCode => stock_location,
         :DestinationCode => 'Dest',
         :CustomerUsageType => order.user ? order.user.avalara_entity_use_code.try(:use_code) : ''
@@ -157,6 +157,11 @@ module SpreeAvataxCertified
 
     def customer_usage_type
       order.user ? order.user.avalara_entity_use_code.try(:use_code) : ''
+    end
+
+    def return_line_item_taxes(line_item, quantity)
+      total_tax_amount = line_item.additional_tax_total + line_item.included_tax_total
+      total_tax_amount * (quantity.to_f / line_item.quantity)
     end
   end
 end


### PR DESCRIPTION
### What problem is the code solving?
The amount of an RMA includes both the item's price and the item's tax amount (Eg: an small hoops of USD50 with a tax of USD2, will get the RMA generated with USD52 as amount). When reporting that RMA to avalara, it is getting reported as a return transaction for USD52, and avalara is recalculating taxes based over that amount, which ends up with a transaction for for example USD54.08 (see image attached bellow). 

### How does this change address the problem?
- Updating `return_item_line` payload to include `TaxIncluded` value as true.
- Updating `return_item_line` payload to override the tax value based on the item(s) returned.

### Why is this the best solution?
According to Avalara's api documentation this is commonly used by returns, imported records, or when notifying avalara transactions which tax was calculated in other systems ([Avalara documentation](https://developer.avalara.com/avatax/dev-guide/discounts-and-overrides/overrides/) and [Api documentation](https://developer.avalara.com/api-reference/avatax/rest/v1/models/TaxOverride/))

Passing the override and setting the tax as included will create the avalara's transaction by the total amount refunded.

Another option we have is to simply reduce the transaction's amount by the tax amount when reporting to Avalara, and rely on Avalara recalculating the tax to match the transaction amount; However, that would probably 

### Share the knowledge
This solution would not be 100% accurate all the time though. There are scenarios where the amount returned is not equal to the  item's price, so in those cases we would en up with discrepancies. Even though that is a common scenario, we believe that we can live with that until we think of a better way to solve it. 

Test cases associated to this change were written here https://github.com/mejuri-inc/mejuri-web/pull/1130

**Example RMA transaction BEFORE changes:**
![Screenshot from 2021-07-16 18-23-09](https://user-images.githubusercontent.com/1608166/126162248-cb636a6e-9436-4fa6-8563-5a7bc138e91d.png)
