### PR TITLE
[DL-871] Fix order placed without tax calculated

### DIFF
--- a/app/models/spree_avatax_certified/address.rb
+++ b/app/models/spree_avatax_certified/address.rb
@@ -44,13 +44,13 @@ module SpreeAvataxCertified
       unless order.ship_address.nil?
 
         order_ship_address = order.pos? ? order.purchase_location.stock_location : order.ship_address
-        
+
         shipping_address = {
           :AddressCode => 'Dest',
           :Line1 => order_ship_address.address1,
           :Line2 => order_ship_address.address2,
           :City => order_ship_address.city,
-          :Region => order_ship_address.state_name,
+          :Region => order_ship_address.state_name || order_ship_address.state&.name,
           :Country => order_ship_address.country.iso,
           :PostalCode => order_ship_address.zipcode
         }
@@ -64,7 +64,7 @@ module SpreeAvataxCertified
     def origin_ship_addresses
       stock_addresses = []
       stock_location_ids = stock_location_ids_from_order(order)
-      
+
       Spree::StockLocation.where(id: stock_location_ids).each do |stock_location|
 
         stock_location_address = {

--- a/app/models/spree_avatax_certified/address.rb
+++ b/app/models/spree_avatax_certified/address.rb
@@ -50,7 +50,7 @@ module SpreeAvataxCertified
           :Line1 => order_ship_address.address1,
           :Line2 => order_ship_address.address2,
           :City => order_ship_address.city,
-          :Region => order_ship_address.state_name || order_ship_address.state&.name,
+          :Region => order_ship_address.state_name.presence || order_ship_address.state&.name,
           :Country => order_ship_address.country.iso,
           :PostalCode => order_ship_address.zipcode
         }

--- a/app/models/tax_svc.rb
+++ b/app/models/tax_svc.rb
@@ -15,7 +15,7 @@ class TaxSvc
     response = JSON.parse(res.body)
 
     if response['ResultCode'] != 'Success'
-      logger.info_and_debug("Avatax Error: Order ##{request_hash[:DocCode]}", response)
+      logger.info "Avatax Error: Order ##{request_hash[:DocCode]}, Response: #{response}"
       raise 'error in Tax'
     else
       response

--- a/app/models/tax_svc.rb
+++ b/app/models/tax_svc.rb
@@ -15,7 +15,7 @@ class TaxSvc
     response = JSON.parse(res.body)
 
     if response['ResultCode'] != 'Success'
-      logger.info "Avatax Error: Order ##{request_hash[:DocCode]}, Response: #{response}"
+      logger.info_and_debug("Avatax Error: Order ##{request_hash[:DocCode]}", response)
       raise 'error in Tax'
     else
       response

--- a/spec/models/spree_avatax_certified/address_spec.rb
+++ b/spec/models/spree_avatax_certified/address_spec.rb
@@ -54,6 +54,19 @@ describe SpreeAvataxCertified::Address, :type => :model do
     it 'has the origin address return a hash' do
       expect(address_lines.order_ship_address[0]).to be_kind_of(Hash)
     end
+
+    if 'has attributes that matches' do
+      order_ship_address = order.ship_address
+      ship_address = address_lines.order_ship_address[0]
+
+      expect(ship_address['AddressCode']).to eq('Dest')
+      expect(ship_address['Line1']).to eq(order_ship_address.address1)
+      expect(ship_address['Line2']).to eq(order_ship_address.address2)
+      expect(ship_address['City']).to eq(order_ship_address.city)
+      expect(ship_address['Region']).to eq(order_ship_address.state.name)
+      expect(ship_address['Country']).to eq(order_ship_address.country.iso)
+      expect(ship_address['PostalCode']).to eq(order_ship_address.zipcode)
+    end
   end
 
   describe "#validate" do


### PR DESCRIPTION
We found that we are using state_name from order ship address for Avalara json parameters and some times this value is null. And for this reason we are getting error on tax calculation from Avalara.

The fix implemented use the name attribute from state object if ship_address has state_name attribute nil.