### PR TITLE
[NO-TICKET] Remove automatic update of payment amount

### DIFF
--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -12,11 +12,8 @@ Spree::Payment.class_eval do
   end
 
   def avalara_finalize
-    if self.amount != order.total
-      self.update_attributes(amount: order.total)
-      order.avalara_capture_finalize if avalara_eligible?
-    else
-      order.avalara_capture_finalize if avalara_eligible?
-    end
+    return unless avalara_eligible?
+
+    order.avalara_capture_finalize
   end
 end

--- a/spec/models/spree/payment_decorator_spec.rb
+++ b/spec/models/spree/payment_decorator_spec.rb
@@ -62,14 +62,21 @@ describe Spree::Payment, :type => :model do
     before do
       order.update_attributes(additional_tax_total: 1.to_f)
     end
-    it 'should update the amount to be the order total' do
-      initial_amount = payment.amount
-      payment.avalara_finalize
-      expect(payment.amount).not_to eq(initial_amount)
-    end
+
     it 'should receive avalara_capture_finalize on order' do
       expect(payment.order).to receive(:avalara_capture_finalize)
       payment.avalara_finalize
+    end
+
+    context 'when is not avalara eligible' do
+      before do
+        Spree::Config.avatax_iseligible = false
+      end
+
+      it 'should not receive avalara_capture_finalize' do
+        expect(payment.order).not_to receive(:avalara_capture_finalize)
+        payment.avalara_finalize
+      end
     end
   end
 


### PR DESCRIPTION
We're experiencing the same issue as they were in Solidus: https://github.com/boomerdigital/solidus_avatax_certified/issues/155. 

They fixed it with [this PR](https://github.com/boomerdigital/solidus_avatax_certified/pull/60), so we'll try to see if the same helps us too.