### PR TITLE
[UDL-659] AvalaraTransaction#post_order_to_avalara raise exception in case address fails

### DIFF
--- a/app/controllers/spree/admin/avatax_settings_controller.rb
+++ b/app/controllers/spree/admin/avatax_settings_controller.rb
@@ -67,6 +67,7 @@ module Spree
           Spree::Config.avatax_company_code =taxpref[:avatax_company_code]
           Spree::Config.avatax_read_timeout =taxpref[:avatax_read_timeout]
           Spree::Config.avatax_open_timeout =taxpref[:avatax_open_timeout]
+          Spree::Config.avatax_refuse_checkout_address_validation_error = taxpref[:avatax_refuse_checkout_address_validation_error] || false
 
           respond_to do |format|
             format.html {

--- a/app/models/spree/avalara_transaction.rb
+++ b/app/models/spree/avalara_transaction.rb
@@ -110,6 +110,7 @@ module Spree
       return { TotalTax: '0.00' } if tax_result == 'error in Tax'
       return tax_result if tax_result['ResultCode'] == 'Success'
     end
+
     def post_return_to_avalara(commit = false, invoice_detail = nil, return_auth = nil)
       AVALARA_TRANSACTION_LOGGER.info('starting post return order to avalara')
 

--- a/app/models/spree/calculator/avalara_transaction_calculator.rb
+++ b/app/models/spree/calculator/avalara_transaction_calculator.rb
@@ -13,7 +13,7 @@ module Spree
       item_address = order.ship_address || order.billing_address
       prev_tax_amount = prev_tax_amount(item)
 
-      return prev_tax_amount if %w(address cart).include?(order.state)
+      return prev_tax_amount if %w(cart).include?(order.state)
       return prev_tax_amount if item_address.nil?
       return prev_tax_amount unless calculable.zone.include?(item_address)
 

--- a/app/models/tax_svc.rb
+++ b/app/models/tax_svc.rb
@@ -32,7 +32,7 @@ class TaxSvc # rubocop:disable Metrics/ClassLength
     if response['ResultCode'] != 'Success'
       logger.info_and_debug("Avatax Error: Order ##{order_number}", response)
 
-      raise 'error in Tax' unless Spree::Config.avatax_address_validation
+      raise 'error in Tax' unless Spree::Config.avatax_refuse_checkout_address_validation_error
       raise 'error in Tax' unless response['Messages'].any? do |message|
         ADDRESS_ERRORS.any? { |error| message['Summary'].include? error }
       end

--- a/app/views/spree/admin/avatax_settings/edit.html.erb
+++ b/app/views/spree/admin/avatax_settings/edit.html.erb
@@ -88,6 +88,13 @@
       </p>
     </fieldset>
     <fieldset>
+      <legend><%= t('avatax_refuse_checkout_address_validation_error') %></legend>
+      <p>
+        <label><%= t('enable_avatax_refuse_checkout_address_validation_error') %></label><br />
+        <%= check_box_tag('settings[avatax_refuse_checkout_address_validation_error]', true, Spree::Config.avatax_refuse_checkout_address_validation_error, class: 'avatax') %>
+      </p>
+    </fieldset>
+    <fieldset>
       <legend><%= t('avatax_tax_calculation') %></legend>
       <p>
         <label><%= t('enable_avatax_tax_calculation') %></label><br />

--- a/app/views/spree/admin/avatax_settings/show.html.erb
+++ b/app/views/spree/admin/avatax_settings/show.html.erb
@@ -48,6 +48,10 @@
     <td><%= Spree::Config.avatax_address_validation %></td>
   </tr>
   <tr>
+    <th scope="row">Refuse Checkout if Address Validation Fails:</th>
+    <td><%= Spree::Config.avatax_refuse_checkout_address_validation_error %></td>
+  </tr>
+  <tr>
     <th scope="row"><%= t("avatax_address_validation_enabled_countries") %>:</th>
     <% address_validated_countries = Spree::Config.avatax_address_validation_enabled_countries %>
     <td>

--- a/lib/spree_avatax_certified/engine.rb
+++ b/lib/spree_avatax_certified/engine.rb
@@ -28,6 +28,7 @@ module SpreeAvataxCertified
         preference :avatax_log_to_stdout, :boolean, default: false
         preference :avatax_read_timeout, :integer, default: 10
         preference :avatax_open_timeout, :integer, default: 5
+        preference :avatax_refuse_checkout_address_validation_error, :boolean, default: false
       end
     end
 


### PR DESCRIPTION
### What problem is the code solving?
Validate address information using Avalara response. Whenever a customer inputs an invalid address, we need to fix the address somehow (often communicating with the customer) to update the address. Not only that, but also the Avalara's calculation defaults the taxes to 0, which means not charging the customer taxes.

### How does this change address the problem?
- Updating `TaxSvc#get_tax` to check if response's error includes certain phrases related to known address errors, and if it does raise a custom exception. This custom exception will be notified to Sentry as well.
- Updating `Spree::Calculator::AvalaraTransactionCalculator ` to allow tax calculation when the order is in `address` step. This change is needed due to how the Spree's state machine is configured. Since we need the address validation when the order is being transitioned to "delivery" we need to move the taxes calculation from when the order is "delivery" to when it is "address". 

### Why is this the best solution?
Raising an exception at that point will halt the process. The exception will be capture on our Spree implementation where we can halt the order's transition between states and communicate that error to our Front-end application.

On relation to the notification, since it is a very key part of the code. We want to keep a monitor to this logic, but we also want to be notified when something is wrong and not everytime a customer fills in a wrong address. Because of that, notifying to Sentry will allow us to keep seeing these errors, and we can configure an alert policy that will allow us to notify in our slack channel whenever we exceed a certain threshold of errors in X minutes.

### Share the knowledge
The current code from Avalara is offering us a `validate` for the address. Do not use that method since that method is currently reporting well formed addresses as invalid (weird). Probably we can even get rid of that call during the `Spree::AvalaraTransaction#post_order_to_avalara` method.

Due to problems running units in this repo. I am adding new unit tests in our `mejuri-web` repo